### PR TITLE
changed to valid category

### DIFF
--- a/workflow-templates/gitleaks-secret-scan.properties.json
+++ b/workflow-templates/gitleaks-secret-scan.properties.json
@@ -2,5 +2,5 @@
   "name": "GitLeaks Secret Scan",
   "description": "Detects passwords, API keys, private keys, and other secrets that have been committed to the codebase.",
   "iconName": "gitleaks",
-  "categories": ["Security"]
+  "categories": ["monitoring"]
 }


### PR DESCRIPTION
The GitLeaks workflow wasn't showing up with our other starter workflows. I did some more reading and I realized that I didn't have a valid category in the json file (I thought categories were arbitrary). Now I know 😅 