### PR TITLE
run gitleaks on all branches by default

### DIFF
--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -1,6 +1,20 @@
 name: GitLeaks Secret Scan
 
-on: [push, pull_request, workflow_dispatch]
+# It's recommended to leave the triggers like this
+# to reduce workflows running on all branches. To
+# catch commited secrets sooner, please install a
+# pre-commit hook as shown at:
+# https://github.com/zricethezav/gitleaks#pre-commit
+on:
+  push:
+    branches:
+      - $default-branch
+  pull_request:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+    branches:
+      - $default-branch
 
 jobs:
   gitleaks:

--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -1,18 +1,6 @@
 name: GitLeaks Secret Scan
 
-# Only scans the main branch by default.
-# It's recommended to add other branches
-# to catch commited secrets sooner.
-on:
-  push:
-    branches:
-      - $default-branch
-  pull_request:
-    branches:
-      - $default-branch
-  workflow_dispatch:
-    branches:
-      - $default-branch
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   gitleaks:


### PR DESCRIPTION
Before it was just on the main branch. It's better to catch secrets sooner.