### PR TITLE
using updated gitleaks action

### DIFF
--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -27,6 +27,7 @@ jobs:
       run: mkdir security && wget -P security/ https://raw.githubusercontent.com/zricethezav/gitleaks/master/config/gitleaks.toml
 
     - name: Run GitLeaks Scan
-      uses: zricethezav/gitleaks-action@master
-      with:
-        config-path: security/gitleaks.toml
+        id: gitleaks
+        uses: DariuszPorowski/github-action-gitleaks@v2
+        with:
+          config-path: security/gitleaks.toml


### PR DESCRIPTION
I figured out that the reason for all the Generic API Key false positives was because the GitHub action for GitLeaks was using an older version, and was causing the rule to match on weird things due to a config incompatibility. I thought that using the newest config with the older action would be fine because it worked in the repos I had used to test so far with no false positives. I'm glad Shane caught it creating FPs on it-webapi-template before we start asking people to implement the workflow.

To fix the problem, I found an updated action that keeps the GitLeaks version up to date, and I added that instead. I tested this workflow on the it-webapi-template repo using [nektos/act](https://github.com/nektos/act) and it came back with no FPs even with the Generic API Key rule enabled.

To avoid this situation in the future, I'll try to monitor the new action we are using and help maintain it so it stays up to date.