### PR TITLE
fixed config input parameter name

### DIFF
--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -30,4 +30,4 @@ jobs:
         id: gitleaks
         uses: DariuszPorowski/github-action-gitleaks@v2
         with:
-          config-path: security/gitleaks.toml
+          config: security/gitleaks.toml


### PR DESCRIPTION
I didn't realize the input parameter for specifying the config was wrong. The action was using a default config which was fine, but I want it to use the latest config as intended.