### PR TITLE
remove branch specification from workflow dispatch trigger

### DIFF
--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -13,8 +13,6 @@ on:
     branches:
       - $default-branch
   workflow_dispatch:
-    branches:
-      - $default-branch
 
 jobs:
   gitleaks:
@@ -28,6 +26,6 @@ jobs:
 
       - name: Run GitLeaks Scan
         id: gitleaks
-        uses: DariuszPorowski/github-action-gitleaks@v2
+        uses: lawndoc/gitleaks-action@v2
         with:
           config: security/gitleaks.toml

--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -26,6 +26,6 @@ jobs:
 
       - name: Run GitLeaks Scan
         id: gitleaks
-        uses: lawndoc/gitleaks-action@v2
+        uses: DariuszPorowski/github-action-gitleaks@v2
         with:
           config: security/gitleaks.toml


### PR DESCRIPTION
After having a bug with the GitLeaks action we were using and the maintainer being very slow to merge our fix, I've decided to fork the action and own it myself to increase the stability of the action moving forward.

As a side note - I also noticed and removed the branch specification from the workflow dispatch trigger because it doesn't need it.