### PR TITLE
modified to use Vermeer's forked definitions

### DIFF
--- a/workflow-templates/gitleaks.yml
+++ b/workflow-templates/gitleaks.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v1
 
-      - name: Update Secret Definitions # from the GitLeaks main repository
-        run: mkdir security && wget -P security/ https://raw.githubusercontent.com/zricethezav/gitleaks/master/config/gitleaks.toml
+      - name: Use Vermeer Definitions # forked from official repo with exceptions for false positives
+        run: mkdir security && wget -P security/ https://raw.githubusercontent.com/vermeer-corp/gitleaks/master/config/gitleaks.toml
 
       - name: Run GitLeaks Scan
         id: gitleaks


### PR DESCRIPTION
Added forked config file to allow us to add exceptions for internal false positives.

I tested the [current config](https://github.com/vermeer-corp/gitleaks/blob/master/config/gitleaks.toml) on the API that @churchs19 messaged me about and it no longer has any false positives. I modified the Generic API Key rule (starts near line 1150).